### PR TITLE
[Incomplete] CosmosPagedResults<T> NextPageToken is now base64 encoded

### DIFF
--- a/src/Cosmonaut/Extensions/CosmosResultExtensions.cs
+++ b/src/Cosmonaut/Extensions/CosmosResultExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Cosmonaut.Diagnostics;
@@ -201,6 +202,9 @@ namespace Cosmonaut.Extensions
                         break;
                 }
             }
+
+            if (!string.IsNullOrWhiteSpace(nextPageToken))
+                nextPageToken = Convert.ToBase64String(Encoding.ASCII.GetBytes(nextPageToken));
             return new CosmosPagedResults<T>(results, pageSize, nextPageToken, queryable);
         }
 
@@ -226,6 +230,8 @@ namespace Cosmonaut.Extensions
                         break;
                 }
             }
+            if (!string.IsNullOrWhiteSpace(nextPageToken))
+                nextPageToken = Convert.ToBase64String(Encoding.ASCII.GetBytes(nextPageToken));
             return new CosmosPagedResults<T>(results, pageSize, nextPageToken, queryable);
         }
 

--- a/src/Cosmonaut/Extensions/PaginationExtensions.cs
+++ b/src/Cosmonaut/Extensions/PaginationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using Microsoft.Azure.Documents.Client;
 
 namespace Cosmonaut.Extensions
@@ -40,7 +41,10 @@ namespace Cosmonaut.Extensions
                 throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be a positive number.");
             }
 
-            return GetQueryableWithPaginationSettings(queryable, continuationToken, pageSize);
+            if (!string.IsNullOrWhiteSpace(continuationToken))
+                continuationToken = Encoding.ASCII.GetString(Convert.FromBase64String(continuationToken));
+
+            return GetQueryableWithPaginationSettings(queryable, continuationToken , pageSize);
         }
 
         private static IQueryable<T> GetQueryableWithPaginationSettings<T>(IQueryable<T> queryable, string continuationInfo, int pageSize)


### PR DESCRIPTION
Hey there,

Firstly, I'm not entirely sure if you will want to merge this, this is more of a discussion based pull request and I'm happy to modify to your suggestions. 

I found that while using the CosmosPagedResults model, the NextPageToken was a JSON formatted string meaning that the token is full of quotes and special characters, requiring character escapes and URL encoding so that it can be safely consumed from an endpoint. This causes the string to become quite long after encoding in comparison.
What I am referring to is when the token is passed via a URL Query we end up with this:
```
INVALID REQUEST: 
https://blah.com/api/sample?token={"token":"+RID:7c9mANLy5WhIAAAAAAAAAA==#RT:1#TRC:10#RTD:jesyMDE4LTEwLTA3VDA2OjI1OjI2LjAzMzMyNzVa#FPC:AT4AAAAAAAAASwAAAAAAAAA=","range":{"min":"","max":"FF"}}

VALID REQUEST (265 Chars):
https://blah.com/api/sample?token=%7B%22token%22%3A%22%2BRID%3A7c9mANLy5WhIAAAAAAAAAA%3D%3D%23RT%3A1%23TRC%3A10%23RTD%3AjesyMDE4LTEwLTA3VDA2OjI1OjI2LjAzMzMyNzVa%23FPC%3AAT4AAAAAAAAASwAAAAAAAAA%3D%22%2C%22range%22%3A%7B%22min%22%3A%22%22%2C%22max%22%3A%22FF%22%7D%7D

```

when we could end up with a much more friendly url like this instead:
```
INVALID REQUEST: (246 Chars)
https://blah.com/api/sample?token=eyJ0b2tlbiI6IitSSUQ6N2M5bUFOTHk1V2hJQUFBQUFBQUFBQT09I1JUOjEjVFJDOjEwI1JURDpqZXN5TURFNExURXdMVEEzVkRBMk9qSTFPakkyTGpBek16TXlOelZhI0ZQQzpBVDRBQUFBQUFBQUFTd0FBQUFBQUFBQT0iLCJyYW5nZSI6eyJtaW4iOiIiLCJtYXgiOiJGRiJ9fQ==

VALID REQUEST (244 Chars)
https://blah.com/api/sample?token=eyJ0b2tlbiI6IitSSUQ6N2M5bUFOTHk1V2hJQUFBQUFBQUFBQT09I1JUOjEjVFJDOjEwI1JURDpqZXN5TURFNExURXdMVEEzVkRBMk9qSTFPakkyTGpBek16TXlOelZhI0ZQQzpBVDRBQUFBQUFBQUFTd0FBQUFBQUFBQT0iLCJyYW5nZSI6eyJtaW4iOiIiLCJtYXgiOiJGRiJ9fQ
```

### Problems & Questions currently: 
 - The base64 padding will need to be trimmed and the length inferred when reading the token
   - `=` = bad
   - This is an easy fix: https://stackoverflow.com/a/26354677
 - What if the client wants to parse the token from JSON?
   - This is still possible, how ever it will require them to decode the token, infer the length etc themselves
   - Is this something that people will ever need to do?
   - Could we potentially add a `NextPageTokenRaw` property?

