### PR TITLE
Make `SetFeedOptionsForSingleOperation` shorter and more readable

### DIFF
--- a/src/Cosmonaut/Extensions/CosmosResultExtensions.cs
+++ b/src/Cosmonaut/Extensions/CosmosResultExtensions.cs
@@ -149,15 +149,8 @@ namespace Cosmonaut.Extensions
 
         private static void SetFeedOptionsForSingleOperation<T>(ref IQueryable<T> queryable, out FeedOptions feedOptions)
         {
-            feedOptions = queryable.GetFeedOptionsForQueryable();
-            if (feedOptions != null)
-            {
-                feedOptions.MaxItemCount = 1;
-                queryable.SetFeedOptionsForQueryable(feedOptions);
-                return;
-            }
-
-            feedOptions = new FeedOptions {MaxItemCount = 1};
+            feedOptions = queryable.GetFeedOptionsForQueryable() ?? new FeedOptions();
+            feedOptions.MaxItemCount = 1;
             queryable.SetFeedOptionsForQueryable(feedOptions);
         }
 


### PR DESCRIPTION
Make `SetFeedOptionsForSingleOperation` shorter and more readable by using `??` operator that removes the code duplication.